### PR TITLE
Refactor Cookers to be more extendible

### DIFF
--- a/src/commands/cook_command.zig
+++ b/src/commands/cook_command.zig
@@ -1,10 +1,10 @@
 const std = @import("std");
 
+const cookers = @import("../cookers/cooker.zig").cooker_registry;
 const AssetScanner = @import("../assets/asset_scanner.zig").AssetScanner;
 const FLAG_ERRORED = @import("../cache/entry.zig").FLAG_ERRORED;
 const Staleness = @import("../cache/staleness.zig").Staleness;
 const CacheEntry = @import("../cache/entry.zig").CacheEntry;
-const GLBCooker = @import("../gltf/cook.zig").GLBCooker;
 const cache_mod = @import("../cache/cache.zig");
 const log = @import("../logger.zig");
 const Cache = cache_mod.Cache;
@@ -125,16 +125,13 @@ pub const CookCommand = struct {
             var file_writer = cooked.file.writer(self.io, &buf);
 
             const cook_failed = blk: {
-                if (entry.extension == .glb) {
-                    var glb_cooker = GLBCooker.init(self.allocator, self.io, self.source, entry.path) catch |err| {
+                if (cookers.get(entry.extension)) |cooker| {
+                    cooker.cook(self.allocator, self.io, self.source, entry.path, &file_writer.interface) catch |err| {
                         log.err("Failed to cook '{s}': {s}", .{ entry.path, @errorName(err) });
                         break :blk true;
                     };
-                    defer glb_cooker.deinit();
-                    glb_cooker.cook(self.allocator, &file_writer.interface) catch |err| {
-                        log.err("Failed to cook '{s}': {s}", .{ entry.path, @errorName(err) });
-                        break :blk true;
-                    };
+                } else {
+                    log.warn("No cooker registered for extension '{s}', skipping '{s}'", .{ entry.extension.string(), entry.path });
                 }
                 break :blk false;
             };

--- a/src/commands/inspect_command.zig
+++ b/src/commands/inspect_command.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 
 const log = @import("../logger.zig");
-const inspector_registry = @import("../inspectors/inspect.zig").inspector_registry;
+const inspectors = @import("../inspectors/inspect.zig").inspector_registry;
 
 pub const InspectError = error{
     NotEnoughArguments,
@@ -44,7 +44,7 @@ pub const InspectCommand = struct {
         var magic: [5]u8 = undefined;
         _ = try reader.readSliceAll(&magic);
 
-        const inspector = inspector_registry.get(&magic) orelse {
+        const inspector = inspectors.get(&magic) orelse {
             log.err("No inspector found for file with magic '{s}'", .{magic});
             return InspectError.UnkownFormat;
         };
@@ -129,4 +129,3 @@ test "InspectCommand.deinit cleans up without error" {
     const cmd = try InspectCommand.parseFromArgs(testing.allocator, testing.io, args);
     cmd.deinit();
 }
-

--- a/src/cookers/cooker.zig
+++ b/src/cookers/cooker.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+
+const Extension = @import("../assets/asset.zig").Extension;
+
+pub const Cooker = struct {
+    cookFn: *const fn (
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        source_dir: std.Io.Dir,
+        file_path: []const u8,
+        writer: *std.Io.Writer,
+    ) anyerror!void,
+
+    pub fn cook(
+        self: Cooker,
+        allocator: std.mem.Allocator,
+        io: std.Io,
+        source_dir: std.Io.Dir,
+        file_path: []const u8,
+        writer: *std.Io.Writer,
+    ) !void {
+        return self.cookFn(allocator, io, source_dir, file_path, writer);
+    }
+};
+
+const glb_cooker = @import("glb.zig").cooker();
+
+pub const cooker_registry = std.EnumArray(Extension, ?Cooker).init(.{
+    .glb = glb_cooker,
+    .gltf = glb_cooker,
+    .other = null,
+});
+
+const testing = std.testing;
+
+var test_called: bool = false;
+
+fn stubCook(_: std.mem.Allocator, _: std.Io, _: std.Io.Dir, _: []const u8, _: *std.Io.Writer) anyerror!void {
+    test_called = true;
+}
+
+fn failingCook(_: std.mem.Allocator, _: std.Io, _: std.Io.Dir, _: []const u8, _: *std.Io.Writer) anyerror!void {
+    return error.TestCookFailed;
+}
+
+test "Cooker.cook calls the provided function pointer" {
+    test_called = false;
+    const cooker = Cooker{ .cookFn = stubCook };
+
+    var buf: [1]u8 = .{0};
+    var writer = std.Io.Writer.fixed(&buf);
+    try cooker.cook(testing.allocator, testing.io, std.Io.Dir.cwd(), "", &writer);
+
+    try testing.expect(test_called);
+}
+
+test "Cooker.cook propagates errors from cookFn" {
+    const cooker = Cooker{ .cookFn = failingCook };
+
+    var buf: [1]u8 = .{0};
+    var writer = std.Io.Writer.fixed(&buf);
+    try testing.expectError(error.TestCookFailed, cooker.cook(testing.allocator, testing.io, std.Io.Dir.cwd(), "", &writer));
+}
+
+test "Cooker struct size is one pointer wide" {
+    try testing.expectEqual(
+        @sizeOf(*const fn (std.mem.Allocator, std.Io, std.Io.Dir, []const u8, *std.Io.Writer) anyerror!void),
+        @sizeOf(Cooker),
+    );
+}
+
+test "cooker_registry contains glb" {
+    try testing.expect(cooker_registry.get(.glb) != null);
+}
+
+test "cooker_registry contains gltf" {
+    try testing.expect(cooker_registry.get(.gltf) != null);
+}
+
+test "cooker_registry returns null for unknown extension" {
+    try testing.expectEqual(@as(?Cooker, null), cooker_registry.get(.other));
+}
+
+test "cooker_registry maps glb and gltf to same cooker" {
+    const glb = cooker_registry.get(.glb).?;
+    const gltf = cooker_registry.get(.gltf).?;
+    try testing.expectEqual(glb.cookFn, gltf.cookFn);
+}

--- a/src/cookers/glb.zig
+++ b/src/cookers/glb.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+
+const Cooker = @import("cooker.zig").Cooker;
+const GLBCooker = @import("../gltf/cook.zig").GLBCooker;
+
+pub fn cooker() Cooker {
+    return .{ .cookFn = cookGlb };
+}
+
+fn cookGlb(
+    allocator: std.mem.Allocator,
+    io: std.Io,
+    source_dir: std.Io.Dir,
+    file_path: []const u8,
+    writer: *std.Io.Writer,
+) !void {
+    var glb_cooker = try GLBCooker.init(allocator, io, source_dir, file_path);
+    defer glb_cooker.deinit();
+    try glb_cooker.cook(allocator, writer);
+}

--- a/src/formats/zmesh.zig
+++ b/src/formats/zmesh.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const mesh = @import("../assets/cooked/mesh.zig");
 
-pub const MAGIC = "ZMESH";
+pub const MAGIC = @import("../shared/constants.zig").FORMAT_MAGIC.ZMESH;
 pub const ZMESH_VERSION: u32 = 1;
 
 pub const HEADER_SIZE: u32 = MAGIC.len // magic

--- a/src/inspectors/inspect.zig
+++ b/src/inspectors/inspect.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const FORMAT_MAGIC = @import("../shared/constants.zig").FORMAT_MAGIC;
+
 pub const FormatInspector = struct {
     inspectFn: *const fn (
         allocator: std.mem.Allocator,
@@ -11,14 +13,12 @@ pub const FormatInspector = struct {
     }
 };
 
-const zmesh_magic = @import("../formats/zmesh.zig").MAGIC;
-const zcache_magic = @import("../cache/cache.zig").MAGIC;
 const zamesh_inspector = @import("../inspectors/zmesh.zig").inspector();
 const zcache_inspector = @import("../inspectors/zcache.zig").inspector();
 
 pub const inspector_registry = std.StaticStringMap(FormatInspector).initComptime(.{
-    .{ zmesh_magic, zamesh_inspector },
-    .{ zcache_magic, zcache_inspector },
+    .{ FORMAT_MAGIC.ZMESH, zamesh_inspector },
+    .{ FORMAT_MAGIC.ZACHE, zcache_inspector },
 });
 
 const testing = std.testing;
@@ -57,7 +57,7 @@ test "FormatInspector struct size is one pointer wide" {
 }
 
 test "inspector_registry contains ZMESH magic" {
-    try testing.expect(inspector_registry.get(zmesh_magic) != null);
+    try testing.expect(inspector_registry.get(FORMAT_MAGIC.ZMESH) != null);
 }
 
 test "inspector_registry returns null for unknown magic" {
@@ -65,6 +65,6 @@ test "inspector_registry returns null for unknown magic" {
 }
 
 test "inspector_registry maps ZMESH to zamesh_inspector" {
-    const found = inspector_registry.get(zmesh_magic).?;
+    const found = inspector_registry.get(FORMAT_MAGIC.ZMESH).?;
     try testing.expectEqual(zamesh_inspector.inspectFn, found.inspectFn);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -29,6 +29,8 @@ test {
     _ = @import("gltf/glb_reader.zig");
     _ = @import("gltf/gltf_json_parser.zig");
     _ = @import("gltf/mesh.zig");
+    _ = @import("cookers/cooker.zig");
+    _ = @import("cookers/glb.zig");
     _ = @import("inspectors/inspect.zig");
     _ = @import("inspectors/zmesh.zig");
     _ = @import("inspectors/zcache.zig");

--- a/src/shared/constants.zig
+++ b/src/shared/constants.zig
@@ -1,0 +1,4 @@
+pub const FORMAT_MAGIC = struct {
+    pub const ZMESH = "ZMESH";
+    pub const ZACHE = "ZACHE";
+};


### PR DESCRIPTION
Small refactor to make cookers more like inspectors, 

Now you register a "cooker into a registry, and then we deterministically find the appropriate cooker based on source file extension