### PR TITLE
Improve zcache

### DIFF
--- a/src/cache/cache.zig
+++ b/src/cache/cache.zig
@@ -7,7 +7,7 @@ const fnv1a = source_file_mod.fnv1a;
 const SourceFile = source_file_mod.SourceFile;
 const log = @import("../logger.zig");
 
-pub const VERSION = 1;
+pub const VERSION = 2;
 pub const MAGIC = "ZACHE";
 
 pub const HEADER_SIZE: u32 = MAGIC.len + @sizeOf(u16) + @sizeOf(u32); // magic + version + entry_count
@@ -24,8 +24,9 @@ pub const Cache = struct {
     entries: std.ArrayList(CacheEntry),
     entry_map: EntryMap,
     source_dir: std.Io.Dir,
+    output_dir_path: []const u8 = "",
 
-    pub fn init(allocator: std.mem.Allocator, source_dir: std.Io.Dir) Cache {
+    pub fn init(allocator: std.mem.Allocator, source_dir: std.Io.Dir, output_dir_path: []const u8) !Cache {
         return .{
             .header = .{
                 .entry_count = 0,
@@ -33,6 +34,7 @@ pub const Cache = struct {
             .entry_map = .init(allocator),
             .entries = .empty,
             .source_dir = source_dir,
+            .output_dir_path = try allocator.dupe(u8, output_dir_path),
         };
     }
 
@@ -43,6 +45,7 @@ pub const Cache = struct {
         }
         self.entries.deinit(allocator);
         self.entry_map.deinit();
+        allocator.free(self.output_dir_path);
     }
 
     pub fn pushCacheEntry(self: *Cache, allocator: std.mem.Allocator, entry: CacheEntry) !void {
@@ -125,6 +128,8 @@ pub const Cache = struct {
         try io_writer.writeAll(MAGIC);
         try io_writer.writeInt(u16, self.header.version, .little);
         try io_writer.writeInt(u32, self.header.entry_count, .little);
+        try io_writer.writeInt(u16, @intCast(self.output_dir_path.len), .little);
+        try io_writer.writeAll(self.output_dir_path);
 
         for (self.entries.items) |entry| {
             try io_writer.writeInt(u64, entry.source_path_hash, .little);
@@ -148,7 +153,7 @@ pub const Cache = struct {
         try cwd.rename("tmp.zcache", cwd, ".zcache", io);
     }
 
-    pub fn readFromDir(allocator: std.mem.Allocator, io: std.Io, source_dir: std.Io.Dir) !Cache {
+    pub fn readFromDir(allocator: std.mem.Allocator, io: std.Io, source_dir: std.Io.Dir, output_dir_path: []const u8) !Cache {
         const cwd = std.Io.Dir.cwd();
         const file = try cwd.openFile(io, ".zcache", .{});
         defer file.close(io);
@@ -174,6 +179,31 @@ pub const Cache = struct {
 
         var cache = try readEntries(allocator, version, reader);
         cache.source_dir = source_dir;
+
+        if (!std.mem.eql(u8, cache.output_dir_path, output_dir_path)) {
+            const old_output_dir_path = cache.output_dir_path;
+            defer {
+                cache.deinit(allocator);
+            }
+
+            if (old_output_dir_path.len > 0) {
+                log.info("Output directory changed from '{s}' to '{s}', invalidating cache", .{ old_output_dir_path, output_dir_path });
+                if (std.Io.Dir.openDir(cwd, io, old_output_dir_path, .{})) |old_output_dir| {
+                    for (cache.entries.items) |entry| {
+                        if (entry.cooked_path.len > 0) {
+                            old_output_dir.deleteFile(io, entry.cooked_path) catch |err| {
+                                log.warn("Failed to delete old cooked file '{s}' from '{s}': {s}", .{ entry.cooked_path, old_output_dir_path, @errorName(err) });
+                            };
+                        }
+                    }
+                } else |_| {
+                    log.warn("Could not open old output directory '{s}' to clean up cooked files", .{old_output_dir_path});
+                }
+            }
+
+            return error.OutputDirChanged;
+        }
+
         return cache;
     }
 
@@ -188,6 +218,11 @@ pub const Cache = struct {
 
     fn readEntries(allocator: std.mem.Allocator, version: u16, reader: *std.Io.Reader) !Cache {
         const entry_count = try reader.takeInt(u32, .little);
+
+        const output_dir_path_len = try reader.takeInt(u16, .little);
+        const output_dir_path = try allocator.alloc(u8, output_dir_path_len);
+        errdefer allocator.free(output_dir_path);
+        try reader.readSliceAll(output_dir_path);
 
         var entries: std.ArrayList(CacheEntry) = .empty;
         errdefer {
@@ -250,6 +285,7 @@ pub const Cache = struct {
             .entry_map = entry_map,
             .entries = entries,
             .source_dir = .cwd(),
+            .output_dir_path = output_dir_path,
         };
     }
 };
@@ -275,9 +311,15 @@ fn makeTestEntry(allocator: std.mem.Allocator, source_path: []const u8, cooked_p
 }
 
 fn writeTestCache(writer: *std.Io.Writer, entries: []const CacheEntry) !void {
+    try writeTestCacheWithOutputDir(writer, entries, ".");
+}
+
+fn writeTestCacheWithOutputDir(writer: *std.Io.Writer, entries: []const CacheEntry, output_dir_path: []const u8) !void {
     try writer.writeAll(MAGIC);
     try writer.writeInt(u16, VERSION, .little);
     try writer.writeInt(u32, @intCast(entries.len), .little);
+    try writer.writeInt(u16, @intCast(output_dir_path.len), .little);
+    try writer.writeAll(output_dir_path);
 
     for (entries) |entry| {
         try writer.writeInt(u64, entry.source_path_hash, .little);
@@ -297,26 +339,27 @@ fn writeTestCache(writer: *std.Io.Writer, entries: []const CacheEntry) !void {
 }
 
 test "init returns empty cache" {
-    const c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
+    defer c.deinit(testing.allocator);
     try testing.expectEqual(@as(u32, 0), c.header.entry_count);
     try testing.expectEqual(@as(usize, 0), c.entries.items.len);
     try testing.expectEqual(VERSION, c.header.version);
 }
 
 test "deinit frees allocated entry paths" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     const entry = try makeTestEntry(testing.allocator, "src/model.glb", "model.zmesh");
     try c.pushCacheEntry(testing.allocator, entry);
     c.deinit(testing.allocator);
 }
 
 test "deinit on empty cache does not error" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     c.deinit(testing.allocator);
 }
 
 test "pushCacheEntry adds entry and increments count" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const entry = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -328,7 +371,7 @@ test "pushCacheEntry adds entry and increments count" {
 }
 
 test "pushCacheEntry multiple entries" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     for (0..5) |_| {
@@ -341,7 +384,7 @@ test "pushCacheEntry multiple entries" {
 }
 
 test "lookupEntry returns entry when path hash matches" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const entry = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -355,7 +398,7 @@ test "lookupEntry returns entry when path hash matches" {
 }
 
 test "lookupEntry returns null when not found" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const sf = SourceFile{ .path = "missing.glb", .extension = .glb, .assetType = .mesh };
@@ -363,7 +406,7 @@ test "lookupEntry returns null when not found" {
 }
 
 test "lookupEntryMut returns mutable entry" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const entry = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -378,7 +421,7 @@ test "lookupEntryMut returns mutable entry" {
 }
 
 test "lookupEntryMut returns null when not found" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const sf = SourceFile{ .path = "missing.glb", .extension = .glb, .assetType = .mesh };
@@ -386,7 +429,7 @@ test "lookupEntryMut returns null when not found" {
 }
 
 test "getIdx returns index when entry exists" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const entry = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -398,7 +441,7 @@ test "getIdx returns index when entry exists" {
 }
 
 test "getIdx returns null when entry does not exist" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const sf = SourceFile{ .path = "missing.glb", .extension = .glb, .assetType = .mesh };
@@ -406,7 +449,7 @@ test "getIdx returns null when entry does not exist" {
 }
 
 test "pruneDeleted removes entries not in source list" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const e1 = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -429,7 +472,7 @@ test "pruneDeleted removes entries not in source list" {
 }
 
 test "pruneDeleted returns zero when all entries present" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const e1 = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -446,7 +489,7 @@ test "pruneDeleted returns zero when all entries present" {
 }
 
 test "pruneDeleted removes all entries when source list is empty" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const e1 = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -465,7 +508,7 @@ test "pruneDeleted removes all entries when source list is empty" {
 }
 
 test "pruneDeleted rebuilds entry_map with correct indices" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const e1 = try makeTestEntry(testing.allocator, "a.glb", "a.zmesh");
@@ -494,7 +537,7 @@ test "pruneDeleted rebuilds entry_map with correct indices" {
 }
 
 test "pruneDeleted on empty cache returns zero" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     const empty: []const SourceFile = &.{};
@@ -639,6 +682,8 @@ test "read errors on truncated entry data" {
     try writer.writeAll(MAGIC);
     try writer.writeInt(u16, VERSION, .little);
     try writer.writeInt(u32, 1, .little);
+    try writer.writeInt(u16, 1, .little); // output_dir_path len
+    try writer.writeAll("."); // output_dir_path
     try writer.writeInt(u64, 0xAAAA, .little);
 
     var reader = std.Io.Reader.fixed(buf[MAGIC.len..writer.end]);
@@ -646,7 +691,7 @@ test "read errors on truncated entry data" {
 }
 
 test "read errors on truncated header" {
-    var buf: [8]u8 = undefined;
+    var buf: [16]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buf);
 
     try writer.writeAll(MAGIC);
@@ -659,7 +704,7 @@ test "write then read round-trip preserves all fields" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var c = Cache.init(testing.allocator, tmp.dir);
+    var c = try Cache.init(testing.allocator, tmp.dir, ".");
     defer c.deinit(testing.allocator);
 
     const entry1 = try makeTestEntry(testing.allocator, "models/hero.glb", "hero.zmesh");
@@ -697,7 +742,7 @@ test "write then read round-trip preserves all fields" {
 }
 
 test "write then read round-trip with zero entries" {
-    var c = Cache.init(testing.allocator, .cwd());
+    var c = try Cache.init(testing.allocator, .cwd(), ".");
     defer c.deinit(testing.allocator);
 
     var buf: [4096]u8 = undefined;

--- a/src/commands/cook_command.zig
+++ b/src/commands/cook_command.zig
@@ -18,6 +18,7 @@ pub const CookError = error{
 pub const CookCommand = struct {
     source: std.Io.Dir,
     output: std.Io.Dir,
+    output_path: []const u8 = ".",
     io: std.Io,
     allocator: std.mem.Allocator,
 
@@ -48,6 +49,7 @@ pub const CookCommand = struct {
                     log.err("cook: failed to open output directory '{s}': {s}. Ensure the directory exists and has the correct permissions", .{ args[i + 1], @errorName(err) });
                     return CookError.OutputDirNotFound;
                 };
+                command.output_path = args[i + 1];
                 i += 1;
             }
 
@@ -58,14 +60,15 @@ pub const CookCommand = struct {
     }
 
     pub fn run(self: CookCommand, progress: std.Progress.Node) !void {
-        var cache = Cache.readFromDir(self.allocator, self.io, self.source) catch |err| blk: {
+        var cache = Cache.readFromDir(self.allocator, self.io, self.source, self.output_path) catch |err| blk: {
             switch (err) {
+                error.OutputDirChanged => log.debug("Output directory changed, rebuilding cache", .{}),
                 error.StaleVersion => log.debug("Outdated cache version found, rebuilding entire cache", .{}),
                 error.UnsupportedVersion => log.debug("Corrupt cache found, rebuilding entire cache", .{}),
                 error.FileNotFound => log.debug("No existing cache found, starting fresh", .{}),
                 else => log.debug("Failed to read cache ({s}), starting fresh", .{@errorName(err)}),
             }
-            break :blk Cache.init(self.allocator, self.source);
+            break :blk try Cache.init(self.allocator, self.source, self.output_path);
         };
         defer cache.deinit(self.allocator);
 
@@ -95,16 +98,22 @@ pub const CookCommand = struct {
             if (cache.lookupEntryMut(entry)) |cache_entry| {
                 staleness = try Staleness.check(self.io, self.source, cache_entry, &entry);
                 if (staleness == .cached) {
-                    log.debug("{s} is cached, not cooking", .{entry.path});
-                    cache_count += 1;
-                    continue;
+                    if (self.outputFileExists(cache_entry.cooked_path)) {
+                        log.debug("{s} is cached, not cooking", .{entry.path});
+                        cache_count += 1;
+                        continue;
+                    }
+                    log.debug("{s} cached but output file missing, recooking", .{entry.path});
                 }
 
                 if (staleness == .hash_match) {
-                    const info = try entry.getFileInfo(self.source, self.io);
-                    cache_entry.source_mtime = info.modified_ns;
-                    log.debug("{s} hash match, updated mtime", .{entry.path});
-                    continue;
+                    if (self.outputFileExists(cache_entry.cooked_path)) {
+                        const info = try entry.getFileInfo(self.source, self.io);
+                        cache_entry.source_mtime = info.modified_ns;
+                        log.debug("{s} hash match, updated mtime", .{entry.path});
+                        continue;
+                    }
+                    log.debug("{s} hash match but output file missing, recooking", .{entry.path});
                 }
 
                 if (staleness == .errored) {
@@ -185,6 +194,17 @@ pub const CookCommand = struct {
         });
 
         try cache.write(self.io);
+    }
+
+    fn outputFileExists(self: CookCommand, cooked_path: []const u8) bool {
+        if (cooked_path.len == 0) {
+            return false;
+        }
+
+        const file = self.output.openFile(self.io, cooked_path, .{}) catch return false;
+        file.close(self.io);
+
+        return true;
     }
 
     pub fn deinit(self: CookCommand) void {

--- a/src/inspectors/zcache.zig
+++ b/src/inspectors/zcache.zig
@@ -18,6 +18,7 @@ fn inspectZCache(allocator: std.mem.Allocator, reader: *std.Io.Reader) !void {
     defer c.deinit(allocator);
 
     log.info("zcache v{d}", .{c.header.version});
+    log.info("  Output dir: {s}", .{if (c.output_dir_path.len > 0) c.output_dir_path else "(none)"});
     log.info("  Entries: {d}", .{c.header.entry_count});
 
     var max_source_len: usize = "source".len;
@@ -160,6 +161,8 @@ test "Cache.read accepts zero entries" {
     try writer.writeAll(cache.MAGIC);
     try writer.writeInt(u16, cache.VERSION, .little);
     try writer.writeInt(u32, 0, .little);
+    try writer.writeInt(u16, 1, .little); // output_dir_path len
+    try writer.writeAll("."); // output_dir_path
 
     var reader = std.Io.Reader.fixed(buf[cache.MAGIC.len..writer.end]);
     var c = try cache.Cache.read(testing.allocator, &reader);
@@ -176,6 +179,8 @@ test "Cache.read parses entry fields correctly" {
     try writer.writeAll(cache.MAGIC);
     try writer.writeInt(u16, cache.VERSION, .little);
     try writer.writeInt(u32, 1, .little);
+    try writer.writeInt(u16, 1, .little); // output_dir_path len
+    try writer.writeAll("."); // output_dir_path
 
     try writer.writeInt(u64, 0xAABBCCDD, .little);
     try writer.writeInt(u64, 0x11223344, .little);
@@ -225,6 +230,8 @@ fn writeTestZcache(writer: *std.Io.Writer, opts: TestZcacheOpts) !void {
     try writer.writeAll(cache.MAGIC);
     try writer.writeInt(u16, cache.VERSION, .little);
     try writer.writeInt(u32, opts.entry_count, .little);
+    try writer.writeInt(u16, 1, .little); // output_dir_path len
+    try writer.writeAll("."); // output_dir_path
 
     for (0..opts.entry_count) |i| {
         try writer.writeInt(u64, 0x1000 + i, .little); // source_path_hash


### PR DESCRIPTION
Two bugs I found in zcache
1) if the output dir changes, we weren't re-cooking all the files into the new output dir as they were "cached", so we are now storing the output dir in the cache and will re-cook all files when that path changes
2) if a user manually deletes a file from the output dir and that file is cached, we weren't re-cooking, now we will check the file exists and re-cook if it's deleted